### PR TITLE
fix: Correct the # aboard count

### DIFF
--- a/pkg/server/grpc.go
+++ b/pkg/server/grpc.go
@@ -312,7 +312,7 @@ func (s *manifestServiceServer) constructUpdate(source core.DataSource) *Manifes
 					if slot.GetJumper() != nil {
 						count++
 					} else if g := slot.GetGroup(); g != nil {
-						count += len(g.GetMembers())
+						count += len(g.GetMembers()) + 1
 					}
 				}
 				slotsAvailable = fmt.Sprintf("%d aboard", count)

--- a/pkg/server/grpc.go
+++ b/pkg/server/grpc.go
@@ -284,26 +284,16 @@ func (s *manifestServiceServer) constructUpdate(source core.DataSource) *Manifes
 				}
 			}
 
-			var slotsAvailable string
-			if l.CallMinutes <= 5 {
-				slotsAvailable = fmt.Sprintf("%d aboard", l.SlotsAvailable)
-			} else if l.SlotsAvailable == 1 {
-				slotsAvailable = "1 slot"
-			} else {
-				slotsAvailable = fmt.Sprintf("%d slots", l.SlotsAvailable)
-			}
-
 			load := &Load{
-				Id:                   uint64(l.ID),
-				AircraftName:         l.AircraftName,
-				LoadNumber:           l.LoadNumber,
-				CallMinutes:          int32(l.CallMinutes),
-				CallMinutesString:    callMinutes,
-				SlotsAvailable:       int32(l.SlotsAvailable),
-				SlotsAvailableString: slotsAvailable,
-				IsFueling:            l.IsFueling,
-				IsTurning:            l.IsTurning,
-				IsNoTime:             l.IsNoTime,
+				Id:                uint64(l.ID),
+				AircraftName:      l.AircraftName,
+				LoadNumber:        l.LoadNumber,
+				CallMinutes:       int32(l.CallMinutes),
+				CallMinutesString: callMinutes,
+				SlotsAvailable:    int32(l.SlotsAvailable),
+				IsFueling:         l.IsFueling,
+				IsTurning:         l.IsTurning,
+				IsNoTime:          l.IsNoTime,
 			}
 			for _, j := range l.Tandems {
 				load.Slots = append(load.Slots, s.slotFromJumper(j))
@@ -314,6 +304,16 @@ func (s *manifestServiceServer) constructUpdate(source core.DataSource) *Manifes
 			for _, j := range l.SportJumpers {
 				load.Slots = append(load.Slots, s.slotFromJumper(j))
 			}
+
+			var slotsAvailable string
+			if l.CallMinutes <= 5 {
+				slotsAvailable = fmt.Sprintf("%d aboard", len(load.Slots))
+			} else if l.SlotsAvailable == 1 {
+				slotsAvailable = "1 slot"
+			} else {
+				slotsAvailable = fmt.Sprintf("%d slots", l.SlotsAvailable)
+			}
+			load.SlotsAvailableString = slotsAvailable
 
 			u.Loads.Loads = append(u.Loads.Loads, load)
 		}

--- a/pkg/server/grpc.go
+++ b/pkg/server/grpc.go
@@ -307,7 +307,15 @@ func (s *manifestServiceServer) constructUpdate(source core.DataSource) *Manifes
 
 			var slotsAvailable string
 			if l.CallMinutes <= 5 {
-				slotsAvailable = fmt.Sprintf("%d aboard", len(load.Slots))
+				count := 0
+				for _, slot := range load.Slots {
+					if slot.GetJumper() != nil {
+						count++
+					} else if g := slot.GetGroup(); g != nil {
+						count += len(g.GetMembers())
+					}
+				}
+				slotsAvailable = fmt.Sprintf("%d aboard", count)
 			} else if l.SlotsAvailable == 1 {
 				slotsAvailable = "1 slot"
 			} else {


### PR DESCRIPTION
When the `SlotsAvailable` string switches to # aboard, the # aboard was incorrect, not accounting for group members. Also added correction for when a jumper is manifested multiple times, which most frequently happens when a single coach has multiple hop/pop students. Burble will count the coach multiple times, using up the slots, but that's burble's problem! The # aboard is for the pilot, so try to be as accurate as possible